### PR TITLE
added installation file and explanation + gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+/DATA
+frank.egg-info/*
+__pycache__
+.venv
+venv
+env

--- a/README.md
+++ b/README.md
@@ -1,2 +1,28 @@
 # ratingsapp
 Console line app for self-updating rating system
+
+### Installation
+
+```
+python3 -m venv .venv
+pip install -r requirements.txt
+source .venv/bin/activate
+
+pip install -e .
+```
+
+1. Crates a new virtual env
+2. Install all required packages in this new virtual env
+3. Activates this virtual env
+4. Installs the 'frank' package
+
+### Usage
+
+Navigate to project folder and activate the virtual env. Use the app!
+```
+source .venv/bin/activate
+
+frank list players
+```
+
+It is possible to install package in global python which should enable to use command frank from anywhere. Currently it throws me some error. And maybe it does not know how to find DATA folder if I am anywhere?

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,15 @@
+from importlib.metadata import entry_points
+from setuptools import setup, find_packages
+
+setup(
+    name = 'frank',
+    version = '0.1.0',
+    packages = find_packages(),
+    py_modules=['rankings'],
+    install_requires = ['pandas', 'click', 'editdistance', 'tabulate'],
+    entry_points = {
+        'console_scripts' : [
+            'frank = rankings:rankings',
+        ]
+    }
+)


### PR DESCRIPTION
This should enable installation of package and its usage, after activating virtual environment. If you use global python and have all the packages it should also work, didn't try it. Then you can just skip all commands connected with virtualenv. 

Maybe it won't know how to find DATA folder? 